### PR TITLE
Fix preview commands on macOS and restore the Mermaid opt-in

### DIFF
--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -15,13 +15,13 @@
         "context": [{"key": "mdglance.preview_focused", "operator": "equal", "operand": true}]
     },
     {
-        "keys": ["super+="],
+        "keys": ["super+equals"],
         "command": "mdglance_zoom",
         "args": {"delta": 0.1},
         "context": [{"key": "mdglance.preview_focused", "operator": "equal", "operand": true}]
     },
     {
-        "keys": ["super+-"],
+        "keys": ["super+minus"],
         "command": "mdglance_zoom",
         "args": {"delta": -0.1},
         "context": [{"key": "mdglance.preview_focused", "operator": "equal", "operand": true}]

--- a/MarkdownGlance.sublime-settings
+++ b/MarkdownGlance.sublime-settings
@@ -3,7 +3,7 @@
     "update_delay_ms": 100,
 
     // Mermaid is opt-in because diagram source is sent to mermaid_server.
-    "enable_mermaid": true,
+    "enable_mermaid": false,
     "mermaid_server": "https://mermaid.ink",
 
     // HTTP images and HTTPS-to-HTTP redirects are blocked by default.

--- a/preview/adapter/commands.py
+++ b/preview/adapter/commands.py
@@ -10,10 +10,12 @@ from .container import container
 
 
 def _owned_session(window):
+    # Sheets and views have separate id spaces; surfaces are keyed by view id.
     sheet = window.active_sheet()
+    view = sheet.view() if sheet is not None else None
     return (
-        container.manager.for_surface(sheet.id())
-        if sheet and container.manager
+        container.manager.for_surface(view.id())
+        if view is not None and container.manager
         else None
     )
 
@@ -140,7 +142,8 @@ class MdglanceRunContractTestsCommand(sublime_plugin.WindowCommand):
                     next(
                         sheet
                         for sheet in self.window.sheets()
-                        if sheet.id() == handle.id
+                        if sheet.view() is not None
+                        and sheet.view().id() == handle.id
                     )
                 )
                 == "contract"
@@ -152,9 +155,9 @@ class MdglanceRunContractTestsCommand(sublime_plugin.WindowCommand):
             self.window.focus_group(0)
             backend.reveal(handle)
             assert self.window.active_group() == 0
-            assert self.window.active_sheet_in_group(1).id() == handle.id
+            assert self.window.active_sheet_in_group(1).view().id() == handle.id
             backend.focus(handle)
-            assert self.window.active_sheet().id() == handle.id
+            assert self.window.active_sheet().view().id() == handle.id
             backend.set_title(handle, "Contract renamed")
             results.append({"backend": "phantom_view", "result": "pass"})
         except Exception as error:

--- a/preview/application/usecases.py
+++ b/preview/application/usecases.py
@@ -51,14 +51,20 @@ class UseCases:
         folders = window.folders() if window is not None else []
         return HOST.normalise(folders[0]) if folders else None
 
+    def _active_view_id(self, sheet) -> Optional[int]:
+        # A sheet carries its own id, distinct from the id of the view inside
+        # it. Surfaces are keyed by view id, so always take the sheet's view.
+        view = sheet.view() if sheet is not None else None
+        return view.id() if view is not None else None
+
     def _session_for_active(self, window) -> Optional[PreviewSession]:
         sheet = window.active_sheet()
         if sheet is not None:
-            session = self.manager.for_surface(sheet.id())
-            if session is not None:
-                return session
             view = sheet.view()
             if view is not None:
+                session = self.manager.for_surface(view.id())
+                if session is not None:
+                    return session
                 return self.manager.for_source(window.id(), view.buffer_id())
         return None
 
@@ -132,7 +138,7 @@ class UseCases:
             self.switch_mode(session, PreviewMode.FULL_SCREEN)
         elif (
             session.preview_surface is not None
-            and active.id() == session.preview_surface.id
+            and self._active_view_id(active) == session.preview_surface.id
         ):
             source = self._find_source(session)
             self.backend.close(session.preview_surface)

--- a/tests/state/test_usecases.py
+++ b/tests/state/test_usecases.py
@@ -32,6 +32,22 @@ class Sheet:
         return self._view
 
 
+class SurfaceView:
+    """A plugin-owned preview/TOC view, as seen through its sheet."""
+
+    def __init__(self, identifier):
+        self._id = identifier
+
+    def id(self):
+        return self._id
+
+    def buffer_id(self):
+        return -self._id
+
+    def match_selector(self, point, selector):
+        return False
+
+
 class View:
     def __init__(self, identifier, name="source.md", filename=None, markdown=True):
         self._id = identifier
@@ -40,6 +56,10 @@ class View:
         self.markdown = markdown
         self._sheet = Sheet(identifier + 100, self)
         self._window = None
+
+    def id(self):
+        # A view id is not a buffer id and not a sheet id: three id spaces.
+        return self._id + 200
 
     def buffer_id(self):
         return self._id
@@ -121,7 +141,24 @@ class Backend:
     def focus(self, handle):
         self.focused.append(handle.id)
         window = self.windows[handle.window_id]
-        window._active = Sheet(handle.id, None)
+        window._active = self.sheet_for(handle)
+
+    def sheet_for(self, handle):
+        # Sublime numbers sheets and views separately; never reuse the view id.
+        return Sheet(handle.id + 5000, SurfaceView(handle.id))
+
+    def owner_of(self, sheet_or_view):
+        if sheet_or_view is None:
+            return None
+        view = sheet_or_view.view() if hasattr(sheet_or_view, "view") else sheet_or_view
+        item = self.handles.get(view.id()) if view is not None else None
+        return item[1] if item else None
+
+    def role_of(self, sheet_or_view):
+        if sheet_or_view is None:
+            return None
+        view = sheet_or_view.view() if hasattr(sheet_or_view, "view") else sheet_or_view
+        return self.roles.get(view.id()) if view is not None else None
 
     def move(self, handle, group):
         self.groups[handle.id] = group
@@ -221,7 +258,7 @@ class UseCasesTest(unittest.TestCase):
         self.window._active = self.source.sheet()
         self.usecases.open_side_by_side(self.window)
         self.assertEqual(len(self.manager.sessions_in(1)), 1)
-        self.window._active = Sheet(session.preview_surface.id, None)
+        self.window._active = self.backend.sheet_for(session.preview_surface)
         self.usecases.toggle_full_screen(self.window)
         self.assertEqual(session.mode, PreviewMode.FULL_SCREEN)
         self.assertNotIn(self.source.sheet().id(), self.backend.closed)
@@ -250,10 +287,29 @@ class UseCasesTest(unittest.TestCase):
             reason for sid, reason in self.scheduler.requests if sid == session.id
         ]
         self.assertEqual(reasons, ["open", "edit", "save"])
-        second._active = Sheet(session.preview_surface.id, None)
+        second._active = self.backend.sheet_for(session.preview_surface)
         self.usecases.adjust_zoom(second, 9.0)
         self.assertEqual(session.zoom, 3.0)
         self.assertEqual(reasons, ["open", "edit", "save"])
+
+    def test_preview_commands_survive_a_sheet_id_that_is_not_the_view_id(self):
+        self.usecases.open_side_by_side(self.window)
+        session = self.manager.for_source(1, 10)
+        sheet = self.backend.sheet_for(session.preview_surface)
+        self.assertNotEqual(sheet.id(), session.preview_surface.id)
+        self.window._active = sheet
+
+        self.usecases.adjust_zoom(self.window, 0.5)
+        self.assertEqual(session.zoom, 1.5)
+        self.usecases.adjust_zoom(self.window, reset=True)
+        self.assertEqual(session.zoom, 1.0)
+
+        self.usecases.toggle_full_screen(self.window)
+        self.assertEqual(session.mode, PreviewMode.FULL_SCREEN)
+        self.window._active = self.backend.sheet_for(session.preview_surface)
+        self.usecases.toggle_full_screen(self.window)
+        self.assertIsNone(self.manager.get(session.id))
+        self.assertIn(session.preview_surface.id, self.backend.closed)
 
     def test_absolute_editor_link_is_rejected(self):
         self.usecases.open_side_by_side(self.window)
@@ -261,7 +317,7 @@ class UseCasesTest(unittest.TestCase):
         session.last_document = PreviewDocument(
             1, "", (), (), (), (OUTSIDE, "~/secret")
         )
-        self.window._active = Sheet(session.preview_surface.id, None)
+        self.window._active = self.backend.sheet_for(session.preview_surface)
         with mock.patch.dict(os.environ, {"HOME": HOME, "USERPROFILE": HOME}):
             for index in (0, 1):
                 self.usecases.open_relative(self.window, session.action_token, index)
@@ -291,7 +347,7 @@ class UseCasesTest(unittest.TestCase):
             (),
             (),
         )
-        self.window._active = Sheet(9999, None)
+        self.window._active = Sheet(9999, SurfaceView(9999))
 
         self.usecases.navigate(self.window, first.action_token, "first")
 

--- a/tests/unit/test_package_identity.py
+++ b/tests/unit/test_package_identity.py
@@ -4,15 +4,25 @@ import json
 import os
 import unittest
 
+from MarkdownGlance.preview.domain.contracts import RenderSettings
+
 ROOT = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
 BINDINGS = ("sublime-keymap", "sublime-mousemap")
 PLATFORMS = ("Linux", "OSX", "Windows")
+# Sublime names the "=" and "-" keys on macOS; the literal characters Linux and
+# Windows accept never match there, so the OSX keymap must spell them out.
+MACOS_KEY_NAMES = {"=": "equals", "-": "minus"}
+
+
+def as_macos_key(key):
+    prefix, plus, last = key.replace("ctrl+", "super+").rpartition("+")
+    return prefix + plus + MACOS_KEY_NAMES.get(last, last)
 
 
 def as_macos(bindings):
     macos = copy.deepcopy(bindings)
     for item in macos:
-        item["keys"] = [key.replace("ctrl+", "super+") for key in item.get("keys", ())]
+        item["keys"] = [as_macos_key(key) for key in item.get("keys", ())]
         item["modifiers"] = [
             modifier.replace("ctrl", "super") for modifier in item.get("modifiers", ())
         ]
@@ -50,7 +60,7 @@ class PackageIdentityTest(unittest.TestCase):
                         self.assertTrue(context["key"].startswith("mdglance."), name)
                         self.assertIs(context["operand"], True)
 
-    def test_platform_bindings_differ_only_by_the_macos_command_key(self):
+    def test_platform_bindings_differ_only_by_macos_key_spelling(self):
         for suffix in BINDINGS:
             linux = self.load("Default (Linux).{}".format(suffix))
             self.assertNotEqual(as_macos(linux), linux, suffix)
@@ -60,6 +70,16 @@ class PackageIdentityTest(unittest.TestCase):
             self.assertEqual(
                 self.load("Default (OSX).{}".format(suffix)), as_macos(linux), suffix
             )
+
+    def test_shipped_settings_keep_mermaid_opt_in(self):
+        # The default settings file is what users actually get; a "true" here
+        # sends diagram source to mermaid_server without anyone opting in.
+        path = os.path.join(ROOT, "MarkdownGlance.sublime-settings")
+        with open(path, encoding="utf-8") as source:
+            shipped = source.read()
+        self.assertIn('"enable_mermaid": false', shipped)
+        self.assertNotIn('"enable_mermaid": true', shipped)
+        self.assertFalse(RenderSettings().enable_mermaid)
 
     def test_runtime_selector_is_python_38_compatible(self):
         with open(os.path.join(ROOT, ".python-version"), encoding="ascii") as source:


### PR DESCRIPTION
Zoom and toggle-from-preview did nothing on macOS. Running the manual test plan on macOS turned up two independent causes, both invisible to the Linux release gate, plus a settings default that contradicted its own comment.

## Sheets and views have separate id spaces

`_session_for_active` and `_owned_session` looked surfaces up with `sheet.id()`, but surfaces are keyed by **view** id. Every lookup returned `None` while the preview was focused:

- `adjust_zoom` no-opped, so zoom in/out/reset did nothing
- `toggle_full_screen` could not recognise its own preview
- the zoom palette entries stayed disabled

Measured on this build: sheet `96` vs view `73` for the same preview. Those ids evidently coincide on Linux — `docs/verification/st4200-contract.json` records a `pass` for a contract test that asserts `sheet.id() == handle.id`. The fix takes the sheet's view first, and corrects the same conflation in the contract test's own assertions.

## The state suite encoded the bug

Its fake backend focused a `Sheet(handle.id, None)` — a sheet whose id *is* the view id. The doubles now model three distinct id spaces (buffer, view, sheet), which reproduces the failure headlessly, and `test_preview_commands_survive_a_sheet_id_that_is_not_the_view_id` pins it. Reverting the lookup fails 4 tests.

## Dead zoom key bindings on macOS

The OSX keymap bound `super+=` and `super+-`. Sublime names those keys `equals` and `minus` on macOS and matches nothing for the literal characters, so both bindings were dead. Sublime's own defaults show the split: Linux uses `ctrl+=` only, Windows accepts both spellings, macOS uses `super+equals` only.

`test_platform_bindings_differ_only_by_the_macos_command_key` derived the OSX keymap from the Linux one by substituting the modifier alone, which *required* the broken spelling. It now applies the macOS key names too.

## Mermaid shipped enabled

`MarkdownGlance.sublime-settings` set `"enable_mermaid": true`, directly under the comment explaining that it is opt-in because diagram source is sent to `mermaid_server`, and against both the code default (`RenderSettings.enable_mermaid = False`) and the README. As shipped, diagram source went to mermaid.ink with nobody opting in. Now off, and pinned by a test.

## Verification

Driven through the real Sublime API on **ST 4200 / Python 3.8.12 / macOS arm64**: 127 of 129 checks pass. The two that do not are the Mermaid default this PR fixes and one wrong expectation in the throwaway harness. Coverage included open/toggle for saved and unsaved buffers, edit/save/Save As/delete-on-disk, themes and zoom, short/Unicode/raw-HTML/100 KiB documents, TOC nesting and duplicate headings, local images and remote images against loopback HTTP and HTTPS servers (redirects, loops, timeouts, byte and dimension caps, TLS validation), Mermaid policy, diagnostics redaction, layout and lifecycle including plugin reload, and command/keymap namespace isolation. Contract tests and the 100-sample benchmark both pass on macOS.

70 unit tests green; `compileall` clean.

Not covered: actual key presses (cannot be synthesised — the commands, the `preview_focused` context, and the keymap spellings are verified instead), live coexistence with MarkdownLivePreview (not installed; static isolation checked), a third-party colour scheme, mouse-wheel zoom, and a live mermaid.ink fetch (no diagram source was sent off-box).